### PR TITLE
feat: add move_to_delta primitive + refactor axis-aligned aliases (BACKLOG 6A.1)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -25,53 +25,29 @@
   - *Time*: 30 min
   - *Tag*: `claude-code` (scaffold), then `hardware` (test on robot)
 
-- [ ] **Record calibration grid** — Teleoperate arm to ~75 positions across workspace. X: 0.15–0.35m (5 pts), Y: ±0.15m (5 pts), Z: table to +0.15m (3 heights). Plus 5-10 extra at key locations (home, grasp height). Measure positions with ruler.
-  - *Done when*: `calibration_data.json` has 75+ entries with plausible positions
-  - *Time*: 45–60 min (one longer session)
-  - *Note*: `hardware` — this is the one session that can't be micro
+- [x] **Record calibration grid** — *(skipped — Phase 5.5 abandoned, see DECISIONS.md 2026-04-12)*
 
 ### 5.5.2 Build Joint Lookup
 
-- [ ] **Create `control/joint_lookup.py`** — Load calibration JSON, build KDTree from positions, implement `solve(target_xyz)` with KNN (K=6) + inverse-distance weighting. Add workspace bounds check: refuse targets >5cm from any recorded point. Add `get_workspace_bounds()` method.
-  - *Done when*: Unit test passes: `solve(recorded_point)` returns the recorded joints (± tolerance)
-  - *Time*: 30 min
-  - *Tag*: `claude-code`
+- [x] **Create `control/joint_lookup.py`** — *(skipped — Phase 5.5 abandoned, see DECISIONS.md 2026-04-12)*
 
-- [ ] **Add RBF interpolation option** — Optionally upgrade from KNN to `scipy.interpolate.RBFInterpolator` with thin_plate_spline kernel for smoother results. Keep KNN as fallback.
-  - *Done when*: Both interpolation modes work, can toggle via config
-  - *Time*: 20 min
-  - *Tag*: `claude-code`
+- [x] **Add RBF interpolation option** — *(skipped — Phase 5.5 abandoned, see DECISIONS.md 2026-04-12)*
 
 ### 5.5.3 Build Trajectory Execution
 
-- [ ] **Create `control/trajectory.py`** — `minimum_jerk_joint_trajectory(q_start, q_end, duration, hz)` → (steps, num_joints) array. `compute_duration(q_start, q_end, speed)` with three presets: "slow" (near objects), "normal", "fast" (free space).
-  - *Done when*: Unit test: trajectory starts at q_start, ends at q_end, has zero velocity at endpoints
-  - *Time*: 20 min
-  - *Tag*: `claude-code`
+- [x] **Create `control/trajectory.py`** — *(skipped — Phase 5.5 abandoned, see DECISIONS.md 2026-04-12)*
 
-- [ ] **Create `control/executor.py`** — `TrajectoryExecutor` wrapping the robot. `execute(trajectory, gripper_value)` sends joints at 50Hz with timing control. Position history buffer for `go_back(steps)`.
-  - *Done when*: Can execute a min-jerk trajectory in simulation or dry-run mode
-  - *Time*: 30 min
-  - *Tag*: `claude-code`
+- [x] **Create `control/executor.py`** — *(skipped — Phase 5.5 abandoned, see DECISIONS.md 2026-04-12)*
 
 ### 5.5.4 Wire Into MCP Server
 
-- [ ] **Replace IK path with lookup** — Update the MCP primitives (move_left, move_forward, etc.) to use `JointLookup.solve()` → `minimum_jerk_trajectory()` → `TrajectoryExecutor.execute()` instead of `kinematics.py` FK/IK. Keep `kinematics.py` for simulation fallback.
-  - *Done when*: `move_forward(0.05)` on real hardware actually moves forward 5cm (± 1cm)
-  - *Time*: 30 min
-  - *Note*: `hardware` — needs physical verification
+- [x] **Replace IK path with lookup** — *(skipped — Phase 5.5 abandoned, see DECISIONS.md 2026-04-12)*
 
-- [ ] **Build `calibration/validate_grid.py`** — Command arm to each recorded position sequentially, visually verify accuracy. Flag points with large errors for re-recording.
-  - *Done when*: Arm visits 10+ recorded points and they all look correct
-  - *Time*: 20 min
-  - *Tag*: `claude-code` (scaffold), then `hardware` (run on robot)
+- [x] **Build `calibration/validate_grid.py`** — *(skipped — Phase 5.5 abandoned, see DECISIONS.md 2026-04-12)*
 
 ### 5.5.5 Validate End-to-End
 
-- [ ] **Run a manual pick-and-place** — Using the new lookup-based primitives: move_forward → move_down → grasp → move_up → move_left → release. Does the arm actually do what the primitives say?
-  - *Done when*: You can pick up an object and place it somewhere else using MCP tool calls
-  - *Time*: 30 min
-  - *Note*: `hardware` — the real test
+- [x] **Run a manual pick-and-place** — *(skipped — Phase 5.5 abandoned, see DECISIONS.md 2026-04-12)*
 
 ---
 
@@ -83,15 +59,9 @@
 
 ### 6A.1 Add `move_to_delta` primitive
 
-- [ ] **Implement `move_to_delta(dx, dy, dz)` in server.py** — Read current joints → FK → add delta vector → IK → send joints. Single tool call, diagonal movement. Existing axis-aligned primitives (`move_left`, etc.) become thin wrappers that call `move_to_delta` internally.
-  - *Done when*: `move_to_delta(0.05, -0.03, 0.0)` moves the arm diagonally in sim, tests pass
-  - *Time*: 30 min
-  - *Tag*: `claude-code`
+- [x] **Implement `move_to_delta(dx, dy, dz)` in server.py** — Read current joints → FK → add delta vector → IK → send joints. Single tool call, diagonal movement. Existing axis-aligned primitives (`move_left`, etc.) become thin wrappers that call `move_to_delta` internally.
 
-- [ ] **Refactor axis-aligned primitives as aliases** — `move_left(d)` → `move_to_delta(0, d, 0)`, etc. Keep the old tool names registered (LLM still uses them), but the implementation is a one-liner.
-  - *Done when*: All existing tests still pass, axis-aligned tools call `move_to_delta` internally
-  - *Time*: 20 min
-  - *Tag*: `claude-code`
+- [x] **Refactor axis-aligned primitives as aliases** — `move_left(d)` → `move_to_delta(0, d, 0)`, etc. Keep the old tool names registered (LLM still uses them), but the implementation is a one-liner.
 
 - [ ] **Hardware validation** — Test `move_to_delta` on the real arm. Diagonal move (e.g. 5cm forward + 3cm down) should trace a straight line, not a staircase.
   - *Done when*: Visual confirmation on hardware

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -11,7 +11,8 @@ The core thesis: split reasoning (LLM) from execution (MCP primitives) from perc
 
 ### Working
 
-- **MCP server** with 20 tools: `observe`, `move_to`, `grasp`, `release`, `stop`, `go_back`, `get_status`, `calibrate`, `read_joints`, `send_joints`, `start_episode`, `end_episode`, `move_left`, `move_right`, `move_up`, `move_down`, `move_forward`, `move_back`, `rotate_gripper`, `tilt_gripper`
+- **MCP server** with 21 tools: `observe`, `move_to`, `move_to_delta`, `grasp`, `release`, `stop`, `go_back`, `get_status`, `calibrate`, `read_joints`, `send_joints`, `start_episode`, `end_episode`, `move_left`, `move_right`, `move_up`, `move_down`, `move_forward`, `move_back`, `rotate_gripper`, `tilt_gripper`
+  - `move_to_delta(dx, dy, dz)` — diagonal 3D EE move in a single IK call; axis-aligned primitives are now aliases
 - **Real hardware control** via LeRobot v0.4 SDK — SO-101 follower arm connects, calibrates, reads joints, moves, grasps
 - **PyBullet simulation** with real SO-101 URDF + STL meshes — full pick-and-place verified
 - **MCP-to-Claude integration** — Claude Code can call tools on the real robot via `.mcp.json` (uses `sg dialout` for serial permissions)
@@ -140,10 +141,6 @@ All 8 motion primitives hardware-validated (March 2026):
 
 ## Next Steps
 
-### Phase 5.5 — Fix Motion Control: Joint-Space Lookup (SKIPPED)
-
-Originally planned to replace placo FK/IK with a data-driven lookup table. **Skipped (April 2026)**: the `.pos` suffix bug was the root cause of IK failures — with the fix, placo FK/IK is accurate enough (validated with 10cm XY square on hardware).
-
 ### Phase 6 — Imitation Learning Pipeline (CURRENT)
 
 **Teleoperation recording (DONE)**:
@@ -162,9 +159,9 @@ Originally planned to replace placo FK/IK with a data-driven lookup table. **Ski
 - JSON format: `{ task, primitives: [{tool, args, timestamp}], metadata: {dataset, episode} }`
 
 **Phase 6A — move_to_delta + Segmenter v2 (CURRENT)**:
-- Add `move_to_delta(dx, dy, dz)` primitive — diagonal moves in a single IK call
-- Refactor axis-aligned primitives as aliases to `move_to_delta`
-- Rewrite segmenter: waypoint-based instead of greedy dominant-axis
+- ✅ `move_to_delta(dx, dy, dz)` added — diagonal 3D EE move in one IK call
+- ✅ Axis-aligned primitives refactored as one-liner aliases to `move_to_delta`
+- Rewrite segmenter: waypoint-based instead of greedy dominant-axis (next)
 - **Test Zero**: replay segmenter v2 output on hardware — critical gate for Path B
 
 **Phase 6B — Full Loop (NEXT)**:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -418,13 +418,31 @@ def _joint_move(joint_deltas: dict, action_name: str, action_args: dict) -> str:
 
 @mcp.tool()
 @_safe_tool
+def move_to_delta(dx: float = 0.0, dy: float = 0.0, dz: float = 0.0) -> str:
+    """Move gripper by a 3D Cartesian delta vector in the robot base frame (meters).
+
+    Allows diagonal moves in a single IK call. The axis-aligned primitives
+    (move_left, move_forward, etc.) are convenience aliases for this tool.
+
+    Frame: +X = forward (away from base), +Y = left, +Z = up.
+
+    Args:
+        dx: X displacement in meters (+forward / -back)
+        dy: Y displacement in meters (+left / -right)
+        dz: Z displacement in meters (+up / -down)
+    """
+    return _cartesian_move(dx, dy, dz, "move_to_delta", {"dx": dx, "dy": dy, "dz": dz})
+
+
+@mcp.tool()
+@_safe_tool
 def move_left(distance_m: float = 0.05) -> str:
     """Move gripper left (+Y) in robot base frame.
 
     Args:
         distance_m: Distance in meters (default 0.05 = 5 cm)
     """
-    return _cartesian_move(0, +distance_m, 0, "move_left", {"distance_m": distance_m})
+    return move_to_delta(0, +distance_m, 0)
 
 
 @mcp.tool()
@@ -435,7 +453,7 @@ def move_right(distance_m: float = 0.05) -> str:
     Args:
         distance_m: Distance in meters (default 0.05 = 5 cm)
     """
-    return _cartesian_move(0, -distance_m, 0, "move_right", {"distance_m": distance_m})
+    return move_to_delta(0, -distance_m, 0)
 
 
 @mcp.tool()
@@ -446,7 +464,7 @@ def move_up(distance_m: float = 0.05) -> str:
     Args:
         distance_m: Distance in meters (default 0.05 = 5 cm)
     """
-    return _cartesian_move(0, 0, +distance_m, "move_up", {"distance_m": distance_m})
+    return move_to_delta(0, 0, +distance_m)
 
 
 @mcp.tool()
@@ -457,7 +475,7 @@ def move_down(distance_m: float = 0.05) -> str:
     Args:
         distance_m: Distance in meters (default 0.05 = 5 cm)
     """
-    return _cartesian_move(0, 0, -distance_m, "move_down", {"distance_m": distance_m})
+    return move_to_delta(0, 0, -distance_m)
 
 
 @mcp.tool()
@@ -468,7 +486,7 @@ def move_forward(distance_m: float = 0.05) -> str:
     Args:
         distance_m: Distance in meters (default 0.05 = 5 cm)
     """
-    return _cartesian_move(+distance_m, 0, 0, "move_forward", {"distance_m": distance_m})
+    return move_to_delta(+distance_m, 0, 0)
 
 
 @mcp.tool()
@@ -479,7 +497,7 @@ def move_back(distance_m: float = 0.05) -> str:
     Args:
         distance_m: Distance in meters (default 0.05 = 5 cm)
     """
-    return _cartesian_move(-distance_m, 0, 0, "move_back", {"distance_m": distance_m})
+    return move_to_delta(-distance_m, 0, 0)
 
 
 @mcp.tool()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,10 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]
 # ROS launch_testing plugin conflicts with venv.
 # Run tests with: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -9,6 +9,8 @@ os.environ["SIMULATE"] = "true"
 from mcp_server.server import (
     observe, move_to, grasp, release, stop, go_back, get_status,
     start_episode, end_episode, read_joints, calibrate, send_joints,
+    move_to_delta, move_left, move_right, move_forward, move_back,
+    move_up, move_down,
 )
 
 
@@ -35,6 +37,22 @@ class TestMoveAndGoBack:
     def test_go_back_no_history_fails(self):
         result = _parse(go_back(steps=100))
         assert result["status"] == "failed"
+
+
+class TestMoveToDelta:
+    def test_diagonal_move(self):
+        result = _parse(move_to_delta(0.05, -0.03, 0.0))
+        assert result["status"] == "complete"
+
+    def test_zero_delta(self):
+        result = _parse(move_to_delta(0.0, 0.0, 0.0))
+        assert result["status"] == "complete"
+
+    def test_axis_aliases_delegate(self):
+        # Each alias should produce the same result shape as move_to_delta
+        for fn in (move_left, move_right, move_up, move_down, move_forward, move_back):
+            result = _parse(fn(0.05))
+            assert result["status"] == "complete"
 
 
 class TestGraspRelease:

--- a/uv.lock
+++ b/uv.lock
@@ -800,6 +800,11 @@ dev = [
     { name = "pytest" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "lerobot", extras = ["feetech"], specifier = ">=0.4.4" },
@@ -813,6 +818,9 @@ requires-dist = [
     { name = "requests" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "deepdiff"


### PR DESCRIPTION
- Added move_to_delta(dx, dy, dz) MCP tool — single IK call for diagonal 3D moves
- Refactored move_left/right/up/down/forward/back as one-liner aliases to move_to_delta
- Added TestMoveToDelta test class (diagonal, zero delta, all aliases); 68 tests pass
- BACKLOG.md: checked off 6A.1 tasks; marked all Phase 5.5 skipped tasks as [x]
  so daily_pulse.py now reports Phase 6A as current phase instead of 5.5
- PROJECT_STATUS.md: added move_to_delta to tools list (21 tools), updated Phase 6A
  progress, removed stale Phase 5.5 "Next Steps" section

https://claude.ai/code/session_01XwE1HVWs257YMp7AMQqu5s